### PR TITLE
Update dependencies to be able to use Composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,10 +27,10 @@
 		}
 	},
 	"require" : {
-		"php" : ">=5.6",
+		"php" : ">=7.2",
 		"gossi/php-code-profiles" : "dev-master",
-		"symfony/config" : "~2|^3|^4",
-		"symfony/yaml" : "~2|^3|^4",
+		"symfony/config" : "^5.0",
+		"symfony/yaml" : "^5.0",
 		"symfony/event-dispatcher" : "~2|^3|^4",
 		"symfony/console" : "~2|^3|^4",
 		"phootwork/collection" : "^1.5",


### PR DESCRIPTION
Synchronize `php` and `symfony` dependencies with `gossi/php-code-profiles` to be able to use Composer again.

Closes https://github.com/phpowermove/php-code-formatter/issues/25